### PR TITLE
Testenv as slave

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout Test environment for Metal
         uses: actions/checkout@v2
         with:
-          repository: ${GITHUB_SERVER_URL}/sifive/testenv-metal
+          repository: sifive/testenv-metal
           ref: ${TESTENV_METAL_BRANCH}
           path: .
           submodules: true
@@ -87,7 +87,7 @@ jobs:
       - name: Checkout Test environment for Metal
         uses: actions/checkout@v2
         with:
-          repository: ${GITHUB_SERVER_URL}/sifive/testenv-metal
+          repository: sifive/testenv-metal
           ref: ${TESTENV_METAL_BRANCH}
           path: .
           submodules: false
@@ -134,7 +134,7 @@ jobs:
       - name: Checkout Test environment for Metal
         uses: actions/checkout@v2
         with:
-          repository: ${GITHUB_SERVER_URL}/sifive/testenv-metal
+          repository: sifive/testenv-metal
           ref: ${TESTENV_METAL_BRANCH}
           path: .
           submodules: false

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: Checkout Test environment for Metal
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
         with:
           repository: ${GITHUB_SERVER_URL}/sifive/testenv-metal
           ref: ${TESTENV_METAL_BRANCH}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -2,11 +2,11 @@ name: SCL-metal
 
 on:
   push:
-  # pull_request:
-   #  types: [assigned, opened, synchronize, reopened]
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
 
 env:
-  TESTENV_METAL_BRANCH: project_slave
+  TESTENV_METAL_BRANCH: master
 
 jobs:
   build:
@@ -163,7 +163,7 @@ jobs:
         uses: rtCamp/action-slack-notify@master
         # Only notify slack channel if the build is triggered from SCL-metal
         # or if the local commit is in the master branch
-        # if: ${{ github.event_name == 'pull_request' || env.SCL_METAL_BRANCH == 'master' }}
+        if: ${{ github.event_name == 'pull_request' || env.SCL_METAL_BRANCH == 'master' }}
         env:
             SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
             SLACK_USERNAME: GitHub CI/CD

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -119,7 +119,7 @@ jobs:
       UTEST_TESTS: 0
       UTEST_FAILURES: 0
       UTEST_IGNORED: 0
-      TESTENV_BRANCH: ""
+      SCL_METAL_BRANCH: ""
 
     steps:
       - name: Checkout Test environment for Metal
@@ -152,19 +152,19 @@ jobs:
         run:  echo "Unit test fatal sessions ${UTEST_ABORTS}/${UTEST_SESSIONS}";
               echo "${UTEST_TESTS} Tests ${UTEST_FAILURES} Failures ${UTEST_IGNORED} Ignored"
 
-#      - name: Extract git meta data
-#        run:  BRANCH="$(echo ${GITHUB_REF} | rev | cut -d/ -f1 | rev)";
-#              echo "TESTENV_BRANCH=${BRANCH}" >> $GITHUB_ENV;
-#
-#      - name: Slack Notification
-#        uses: rtCamp/action-slack-notify@master
-#        # Only notify slack channel if the build is triggered from SCL-metal
-#        # or if the local commit is in the master branch
-#        if: ${{ github.event_name == 'workflow_dispatch' || env.TESTENV_BRANCH == 'master' }}
-#        env:
-#            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-#            SLACK_USERNAME: GitHub CI/CD
-#            SLACK_ICON: https://github.com/sifive.png?size=48
+      - name: Extract git meta data
+        run:  BRANCH="$(echo ${GITHUB_REF} | rev | cut -d/ -f1 | rev)";
+              echo "SCL_METAL_BRANCH=${BRANCH}" >> $GITHUB_ENV;
+
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@master
+        # Only notify slack channel if the build is triggered from SCL-metal
+        # or if the local commit is in the master branch
+        # if: ${{ github.event_name == 'pull_request' || env.SCL_METAL_BRANCH == 'master' }}
+        env:
+            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+            SLACK_USERNAME: GitHub CI/CD
+            SLACK_ICON: https://github.com/sifive.png?size=48
 
       - name: Overall result
         run:  test ${BUILD_FAILURES} -eq 0 &&

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -141,7 +141,10 @@ jobs:
             name: utest_result
 
       - name: Load statuses
-        run:  scripts/gh_setenv.sh build_status utest_status
+        run:  scripts/gh_setenv.sh
+                "${GITHUB_EVENT_NAME}"
+                "${GITHUB_SHA}:${{ github.event.pull_request.head.sha }}"
+                build_status utest_status
 
       - name: Report build status
         run:  echo "Build failures ${BUILD_FAILURES}/${BUILD_SESSIONS}";

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,7 +15,7 @@ jobs:
 
     env:
       TARGETS: qemu-sifive_e_rv64 qemu-sifive_e_rv32
-      BUILD_TOTAL: 0
+      BUILD_SESSIONS: 0
       BUILD_FAILURES: 0
       BUILD_WARNINGS: 0
       BUILD_ERRORS: 0
@@ -46,7 +46,7 @@ jobs:
               touch build/.phony
 
       - name: Store build status
-        run:  echo "${BUILD_TOTAL}|${BUILD_FAILURES}|${BUILD_ERRORS}|${BUILD_WARNINGS}" > build_status
+        run:  echo "${BUILD_SESSIONS}|${BUILD_FAILURES}|${BUILD_ERRORS}|${BUILD_WARNINGS}" > build_status
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@v2
@@ -68,7 +68,7 @@ jobs:
     needs: build
 
     env:
-      UTEST_TOTAL: 0
+      UTEST_SESSIONS: 0
       UTEST_ABORTS: 0
       UTEST_TESTS: 0
       UTEST_FAILURES: 0
@@ -96,7 +96,7 @@ jobs:
         run:  docker/bin/dock.sh utest scripts/utestall.sh -g build
 
       - name: Store utest status
-        run: echo "${UTEST_TOTAL}|${UTEST_ABORTS}|${UTEST_TESTS}|${UTEST_FAILURES}|${UTEST_IGNORED}" > utest_status
+        run: echo "${UTEST_SESSIONS}|${UTEST_ABORTS}|${UTEST_TESTS}|${UTEST_FAILURES}|${UTEST_IGNORED}" > utest_status
 
       - name: Upload utest status
         uses: actions/upload-artifact@v2
@@ -110,11 +110,11 @@ jobs:
     needs: [build, utest]
 
     env:
-      BUILD_TOTAL: 0
+      BUILD_SESSIONS: 0
       BUILD_FAILURES: 0
       BUILD_WARNINGS: 0
       BUILD_ERRORS: 0
-      UTEST_TOTAL: 0
+      UTEST_SESSIONS: 0
       UTEST_ABORTS: 0
       UTEST_TESTS: 0
       UTEST_FAILURES: 0
@@ -144,12 +144,12 @@ jobs:
         run:  scripts/gh_setenv.sh build_status utest_status
 
       - name: Report build status
-        run:  echo "Build failures ${BUILD_FAILURES}/${BUILD_TOTAL}";
+        run:  echo "Build failures ${BUILD_FAILURES}/${BUILD_SESSIONS}";
               echo "Build error count ${BUILD_ERRORS}";
               echo "Build warning count ${BUILD_WARNINGS}"
 
       - name: Report unit test status
-        run:  echo "Unit test fatal sessions ${UTEST_ABORTS}/${UTEST_TOTAL}";
+        run:  echo "Unit test fatal sessions ${UTEST_ABORTS}/${UTEST_SESSIONS}";
               echo "${UTEST_TESTS} Tests ${UTEST_FAILURES} Failures ${UTEST_IGNORED} Ignored"
 
 #      - name: Extract git meta data

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -2,22 +2,181 @@ name: SCL-metal
 
 on:
   push:
-  pull_request:
-    types: [assigned, opened, synchronize, reopened]
+  # pull_request:
+   #  types: [assigned, opened, synchronize, reopened]
+
+env:
+    TESTENV_METAL_BRANCH: project_slave
 
 jobs:
-  trigger-event:
+  build:
+    name: Build Metal & Unit Tests
     runs-on: ubuntu-latest
-    env:
-        # post the event to the remote action on the following branch
-        TESTENV_METAL_BRANCH: master
-    steps:
-    - uses: actions/checkout@v2
-    - name: Run trigger script
-      run:  /bin/sh .github/events/trigger_build_test.sh
-            ${TESTENV_METAL_BRANCH}
-            ${GITHUB_EVENT_NAME}
-            "${GITHUB_SHA}:${{ github.event.pull_request.head.sha }}"
-            ${{ secrets.TESTENV_METAL_EVENT_USERNAME }}
-            ${{ secrets.TESTENV_METAL_EVENT_TOKEN }}
 
+    env:
+      TARGETS: qemu-sifive_e_rv64 qemu-sifive_e_rv32
+      BUILD_TOTAL: 0
+      BUILD_FAILURES: 0
+      BUILD_WARNINGS: 0
+      BUILD_ERRORS: 0
+
+  steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: ${GITHUB_SERVER_URL}/sifive/testenv-metal
+        ref: ${TESTENV_METAL_BRANCH}
+        path: .
+        submodules: true
+
+    - uses: actions/checkout@v2
+      with:
+        path: scl-metal
+        submodules: false
+
+    - name: Store scl-metal info
+      run:  (cd scl-metal && git log -1 --pretty=%H:%cn:%B | head -1) > scl_metal_status
+
+    - name: Report submodule status
+      run:  git submodule status
+
+    - name: Fetch Docker image
+      run: docker/bin/dock.sh build /bin/true
+
+    - name: Build all targets
+      run:  docker/bin/dock.sh build scripts/buildall.sh -g -r -s $TARGETS;
+            touch build/.phony
+
+    - name: Store build status
+      run:  echo "${BUILD_TOTAL}|${BUILD_FAILURES}|${BUILD_ERRORS}|${BUILD_WARNINGS}" > build_status
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v2
+      with:
+          name: utests
+          path: |
+              build/**/*.elf
+              build/.phony
+
+    - name: Upload build status
+      uses: actions/upload-artifact@v2
+      with:
+          name: build_result
+          path: build_status
+
+    - name: Upload SCL metal info
+      uses: actions/upload-artifact@v2
+      with:
+          name: scl_info
+          path: scl_metal_status
+
+  utest:
+    name: Run Unit Tests on QEMU
+    runs-on: ubuntu-latest
+    needs: build
+
+    env:
+      UTEST_TOTAL: 0
+      UTEST_ABORTS: 0
+      UTEST_TESTS: 0
+      UTEST_FAILURES: 0
+      UTEST_IGNORED: 0
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: ${GITHUB_SERVER_URL}/sifive/testenv-metal
+          ref: ${TESTENV_METAL_BRANCH}
+          path: .
+          submodules: false
+
+      - name: Fetch Docker image
+        run: docker/bin/dock.sh utest /bin/true
+
+      - name: Download test artifacts
+        uses: actions/download-artifact@v2
+        with:
+            name: utests
+            path: build
+
+      - name: Test all targets
+        run:  docker/bin/dock.sh utest scripts/utestall.sh -g build
+
+      - name: Store utest status
+        run: echo "${UTEST_TOTAL}|${UTEST_ABORTS}|${UTEST_TESTS}|${UTEST_FAILURES}|${UTEST_IGNORED}" > utest_status
+
+      - name: Upload utest status
+        uses: actions/upload-artifact@v2
+        with:
+            name: utest_result
+            path: utest_status
+
+  status:
+    name: Overall status
+    runs-on: ubuntu-latest
+    needs: [build, utest]
+
+    env:
+      BUILD_TOTAL: 0
+      BUILD_FAILURES: 0
+      BUILD_WARNINGS: 0
+      BUILD_ERRORS: 0
+      UTEST_TOTAL: 0
+      UTEST_ABORTS: 0
+      UTEST_TESTS: 0
+      UTEST_FAILURES: 0
+      UTEST_IGNORED: 0
+      TESTENV_BRANCH: ""
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: ${GITHUB_SERVER_URL}/sifive/testenv-metal
+          ref: ${TESTENV_METAL_BRANCH}
+          path: .
+          submodules: false
+
+      - name: Download build result
+        uses: actions/download-artifact@v2
+        with:
+            name: build_result
+
+      - name: Download utest result
+        uses: actions/download-artifact@v2
+        with:
+            name: utest_result
+
+      - name: Download SCL metal info
+        uses: actions/download-artifact@v2
+        with:
+            name: scl_info
+
+      - name: Load statuses
+        run:  scripts/gh_setenv.sh ${GITHUB_EVENT_NAME} build_status utest_status scl_metal_status
+
+      - name: Report build status
+        run:  echo "Build failures ${BUILD_FAILURES}/${BUILD_TOTAL}";
+              echo "Build error count ${BUILD_ERRORS}";
+              echo "Build warning count ${BUILD_WARNINGS}"
+
+      - name: Report unit test status
+        run:  echo "Unit test fatal sessions ${UTEST_ABORTS}/${UTEST_TOTAL}";
+              echo "${UTEST_TESTS} Tests ${UTEST_FAILURES} Failures ${UTEST_IGNORED} Ignored"
+
+#      - name: Extract git meta data
+#        run:  BRANCH="$(echo ${GITHUB_REF} | rev | cut -d/ -f1 | rev)";
+#              echo "TESTENV_BRANCH=${BRANCH}" >> $GITHUB_ENV;
+#
+#      - name: Slack Notification
+#        uses: rtCamp/action-slack-notify@master
+#        # Only notify slack channel if the build is triggered from SCL-metal
+#        # or if the local commit is in the master branch
+#        if: ${{ github.event_name == 'workflow_dispatch' || env.TESTENV_BRANCH == 'master' }}
+#        env:
+#            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+#            SLACK_USERNAME: GitHub CI/CD
+#            SLACK_ICON: https://github.com/sifive.png?size=48
+
+      - name: Overall result
+        run:  test ${BUILD_FAILURES} -eq 0 &&
+              test ${UTEST_ABORTS} -eq 0 &&
+              test ${UTEST_FAILURES} -eq 0

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: sifive/testenv-metal
-          ref: ${TESTENV_METAL_BRANCH}
+          ref: ${{ env.TESTENV_METAL_BRANCH }}
           path: .
           submodules: true
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -6,7 +6,7 @@ on:
    #  types: [assigned, opened, synchronize, reopened]
 
 env:
-    TESTENV_METAL_BRANCH: project_slave
+  TESTENV_METAL_BRANCH: project_slave
 
 jobs:
   build:
@@ -20,54 +20,56 @@ jobs:
       BUILD_WARNINGS: 0
       BUILD_ERRORS: 0
 
-  steps:
-    - uses: actions/checkout@v2
-      with:
-        repository: ${GITHUB_SERVER_URL}/sifive/testenv-metal
-        ref: ${TESTENV_METAL_BRANCH}
-        path: .
-        submodules: true
+    steps:
+      - name: Checkout Test environment for Metal
+        uses: actions/checkout@v2
+        with:
+          repository: ${GITHUB_SERVER_URL}/sifive/testenv-metal
+          ref: ${TESTENV_METAL_BRANCH}
+          path: .
+          submodules: true
 
-    - uses: actions/checkout@v2
-      with:
-        path: scl-metal
-        submodules: false
+      - name: Checkout SCL-Metal
+        uses: actions/checkout@v2
+        with:
+          path: scl-metal
+          submodules: false
 
-    - name: Store scl-metal info
-      run:  (cd scl-metal && git log -1 --pretty=%H:%cn:%B | head -1) > scl_metal_status
+      - name: Store scl-metal info
+        run:  (cd scl-metal && git log -1 --pretty=%H:%cn:%B | head -1) > scl_metal_status
 
-    - name: Report submodule status
-      run:  git submodule status
+      - name: Report submodule status
+        run:  git submodule status
 
-    - name: Fetch Docker image
-      run: docker/bin/dock.sh build /bin/true
+      - name: Fetch Docker image
+        run: docker/bin/dock.sh build /bin/true
 
-    - name: Build all targets
-      run:  docker/bin/dock.sh build scripts/buildall.sh -g -r -s $TARGETS;
-            touch build/.phony
+      - name: Build all targets
+        run:  docker/bin/dock.sh build scripts/buildall.sh -g -r -s $TARGETS;
+              touch build/.phony
 
-    - name: Store build status
-      run:  echo "${BUILD_TOTAL}|${BUILD_FAILURES}|${BUILD_ERRORS}|${BUILD_WARNINGS}" > build_status
+      - name: Store build status
+        run:  echo "${BUILD_TOTAL}|${BUILD_FAILURES}|${BUILD_ERRORS}|${BUILD_WARNINGS}" > build_status
 
-    - name: Upload test artifacts
-      uses: actions/upload-artifact@v2
-      with:
-          name: utests
-          path: |
-              build/**/*.elf
-              build/.phony
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v2
+        with:
+            name: utests
+            path: |
+                build/**/*.elf
+                build/.phony
 
-    - name: Upload build status
-      uses: actions/upload-artifact@v2
-      with:
-          name: build_result
-          path: build_status
+      - name: Upload build status
+        uses: actions/upload-artifact@v2
+        with:
+            name: build_result
+            path: build_status
 
-    - name: Upload SCL metal info
-      uses: actions/upload-artifact@v2
-      with:
-          name: scl_info
-          path: scl_metal_status
+      - name: Upload SCL metal info
+        uses: actions/upload-artifact@v2
+        with:
+            name: scl_info
+            path: scl_metal_status
 
   utest:
     name: Run Unit Tests on QEMU
@@ -82,7 +84,8 @@ jobs:
       UTEST_IGNORED: 0
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Test environment for Metal
+        uses: actions/checkout@v2
         with:
           repository: ${GITHUB_SERVER_URL}/sifive/testenv-metal
           ref: ${TESTENV_METAL_BRANCH}
@@ -128,6 +131,7 @@ jobs:
       TESTENV_BRANCH: ""
 
     steps:
+      - name: Checkout Test environment for Metal
       - uses: actions/checkout@v2
         with:
           repository: ${GITHUB_SERVER_URL}/sifive/testenv-metal

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -35,9 +35,6 @@ jobs:
           path: scl-metal
           submodules: false
 
-      - name: Store scl-metal info
-        run:  (cd scl-metal && git log -1 --pretty=%H:%cn:%B | head -1) > scl_metal_status
-
       - name: Report submodule status
         run:  git submodule status
 
@@ -65,12 +62,6 @@ jobs:
             name: build_result
             path: build_status
 
-      - name: Upload SCL metal info
-        uses: actions/upload-artifact@v2
-        with:
-            name: scl_info
-            path: scl_metal_status
-
   utest:
     name: Run Unit Tests on QEMU
     runs-on: ubuntu-latest
@@ -88,7 +79,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: sifive/testenv-metal
-          ref: ${TESTENV_METAL_BRANCH}
+          ref: ${{ env.TESTENV_METAL_BRANCH }}
           path: .
           submodules: false
 
@@ -135,7 +126,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: sifive/testenv-metal
-          ref: ${TESTENV_METAL_BRANCH}
+          ref: ${{ env.TESTENV_METAL_BRANCH }}
           path: .
           submodules: false
 
@@ -149,13 +140,8 @@ jobs:
         with:
             name: utest_result
 
-      - name: Download SCL metal info
-        uses: actions/download-artifact@v2
-        with:
-            name: scl_info
-
       - name: Load statuses
-        run:  scripts/gh_setenv.sh ${GITHUB_EVENT_NAME} build_status utest_status scl_metal_status
+        run:  scripts/gh_setenv.sh build_status utest_status
 
       - name: Report build status
         run:  echo "Build failures ${BUILD_FAILURES}/${BUILD_TOTAL}";


### PR DESCRIPTION
Invert the way CI/CD is performed:

A copy of `testenv-metal` is checked out before the local repository, and all build and test sessions are run from the tested repository.