### PR TITLE
Dev tests cmdline

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,8 @@ ADD_DEFINITIONS (-Wno-extra-semi-stmt)
 #  this enables running the static analyzer on all the test files, w/o to try
 #  to produce an executable
 ADD_LIBRARY (scl-tests
+  src/cmdline.c
+  src/secmain.S
   src/test_runners/test_utils_runner.c
   src/test_runners/asymmetric/test_scl_ecdsa_runner.c
   src/test_runners/blockcipher/test_scl_aes_runner.c
@@ -49,7 +51,10 @@ ADD_LIBRARY (scl-tests
 IF (NOT DEFINED STATIC_ANALYSIS)
   SET (app test-scl-metal)
 
+  ADD_DEFINITIONS(-DELFNAME="${app}")
   ADD_EXECUTABLE (${app}
+    src/cmdline.c
+    src/secmain.S
     src/test-scl-metal.c
   )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,8 +9,6 @@ ADD_DEFINITIONS (-Wno-extra-semi-stmt)
 #  this enables running the static analyzer on all the test files, w/o to try
 #  to produce an executable
 ADD_LIBRARY (scl-tests
-  src/cmdline.c
-  src/secmain.S
   src/test_runners/test_utils_runner.c
   src/test_runners/asymmetric/test_scl_ecdsa_runner.c
   src/test_runners/blockcipher/test_scl_aes_runner.c

--- a/tests/src/cmdline.c
+++ b/tests/src/cmdline.c
@@ -1,0 +1,88 @@
+/**
+ * @file cmdenv.c
+ * @brief Load command line from virtual machine, if any
+ *
+ * @copyright Copyright (c) 2020 SiFive, Inc
+ * @copyright SPDX-License-Identifier: MIT
+ *
+ */
+
+#include <stdint.h>
+#include <metal/machine/platform.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wmissing-variable-declarations"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#include <metal/machine.h>
+#pragma clang diagnostic pop
+
+static char _cmdline_str[0x100u];
+static const char * _cmdline_argv[16u];
+static int _cmdline_argc;
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(_a_) (sizeof(_a_)/sizeof((_a_)[0]))
+#endif // ARRAY_SIZE
+
+#ifndef ELFNAME
+#define ELFNAME "test"
+#endif
+
+/** Dummy structure to return values in registers a0/a1 */
+struct stack_return
+{
+    uintptr_t sr_argc; /**< a0: argc */
+    uintptr_t sr_argv; /**< a1: argv */
+};
+
+struct stack_return load_cmdline(void);
+
+struct stack_return load_cmdline(void)
+{
+    _cmdline_argc = 0;
+    _cmdline_argv[_cmdline_argc++] = ELFNAME;
+
+#ifdef __METAL_DT_SHUTDOWN_HANDLE
+    // Query VM peripheral for an optional command line
+    unsigned long base;
+    base = __metal_driver_sifive_test0_base(__METAL_DT_SHUTDOWN_HANDLE);
+    // Initialize the query
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + 0x100)) = 0x6c63;
+
+    char * ptr = _cmdline_str;
+    char last = '\0';
+    const char * first = NULL;
+    _cmdline_argv[_cmdline_argc] = ptr;
+
+    // retrieve the command line if any, and slit it into an argv array
+    while ( (ptr-_cmdline_str < (int)sizeof(_cmdline_str)) &&
+            (_cmdline_argc < (int)ARRAY_SIZE(_cmdline_argv)) ) {
+        *ptr = (char)__METAL_ACCESS_ONCE((__metal_io_u32 *)(base + 0x100));
+        if ( ! *ptr ) {
+            break;
+        }
+        if ( *ptr == ' ' ) {
+            if ( last != ' ' && first ) {
+                *ptr ='\0';
+                _cmdline_argv[_cmdline_argc++] = first;
+                first = NULL;
+            }
+        } else if ( ! first ) {
+            first = ptr;
+        }
+        last = *ptr;
+        ptr++;
+    }
+    if ( first ) {
+        _cmdline_argv[_cmdline_argc++] = first;
+    }
+#endif // __METAL_DT_SHUTDOWN_HANDLE
+
+    struct stack_return sr = {
+        .sr_argc = (uintptr_t)_cmdline_argc, /* a0 */
+        .sr_argv = (uintptr_t)_cmdline_argv, /* a1 */
+    };
+
+    return sr;
+}

--- a/tests/src/secmain.S
+++ b/tests/src/secmain.S
@@ -1,0 +1,42 @@
+/**
+ * @file secmain.S
+ * @brief Override secondary_main
+ * @details This run all test group
+ *
+ * @copyright Copyright (c) 2020 SiFive, Inc
+ * @copyright SPDX-License-Identifier: MIT
+ */
+
+.section .text.start
+.global secondary_main
+.type   secondary_main, @function
+
+/*
+ * Overload default secondary_main function to load command line from a QEMU
+ * VM command line if any.
+ *
+ * load_cmdline C function updates a0 with argc and a1 with argv.
+ */
+secondary_main:
+  addi sp, sp, -16
+#if __riscv_xlen == 32
+  sw ra, 4(sp)
+#else
+  sd ra, 8(sp)
+#endif
+  csrr t0, mhartid
+  la t1, __metal_boot_hart
+  beq t0, t1, 2f
+1:
+  wfi
+  j 1b
+2:
+  call load_cmdline
+  call main
+#if __riscv_xlen == 32
+  lw ra, 4(sp)
+#else
+  ld ra, 8(sp)
+#endif
+  addi sp, sp, 16
+  ret


### PR DESCRIPTION
This patch enables test selection from the QEMU command line.

When QEMU FDT is run with the`-append` option switch, the arguments are forwarded as freedom-metal `main()` `argc`/`argv`. When not used, or when QEMU does not support this mode, or with a non-QEMU platform, `main()` behaves at it previously did.

It only patches SCL test environment: neither SCL-metal or freedom-metal is modified.